### PR TITLE
Docker compose fix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,6 @@ steps:
   - name: ":rspec:"
     command: "rspec --color specs"
     plugins:
-      docker-compose#v5.2.0:
+      docker-compose#v5.10.0:
         run: app
         tty: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,3 +4,4 @@ steps:
     plugins:
       docker-compose#v5.2.0:
         run: app
+        tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   app:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
 services:
   app:
     build: .
-    environment:
-      - TERM=xterm-256color
-    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
 services:
   app:
     build: .
+    environment:
+      - TERM=xterm-256color
+    tty: true


### PR DESCRIPTION
Removes the deprecated `version` key, and sets `tty` to `true` in order for color to be passed through, as this defaults to `false` in the Docker Compose plugin now.